### PR TITLE
Fix click plotting coordinates

### DIFF
--- a/script.js
+++ b/script.js
@@ -128,8 +128,7 @@ document.addEventListener("DOMContentLoaded", () => {
         parabolaPoints = [];
       }
     } else {
-      const yv = coefficients[0] * x * x + coefficients[1] * x + coefficients[2];
-      dots.push({ x, y: yv });
+      dots.push({ x, y });
     }
     redraw();
   });


### PR DESCRIPTION
## Summary
- Plot canvas points using actual click coordinates instead of computed parabola values

## Testing
- `npm test` *(fails: sh: 1: null: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689757faefdc8332b4f7736d0eedef93